### PR TITLE
Adding the option to use an `fs.FS` for the file server middleware

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+file/testdata/*.* eol=lf
+file/testdata/*/*.* eol=lf


### PR DESCRIPTION
This pull request adds the option `FS` to the `ServerOptions` of the file server middleware which allows passing an `fs.FS` as content root.

For example, this makes it possible to use static web files directly compiled into the binary using [`embed.FS`](https://pkg.go.dev/embed).

When the `FS` field is specified, this overrides the set `RootPath`. Otherwise, when `FS` is not specified, the given (or default) `RootPath` is used via `os.DirFS`.

Additionally, I've added a `.gitattribute` which specifies the contents of `file/testdata` to be cloned with LF end of lines. Otherwise, all unit tests fail when cloned on a Windows system because files are converted to CLRF.